### PR TITLE
set proper encoding for temporary file to improve support for languages which allow unicode symbol in source

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -1049,8 +1049,10 @@ by quickrun.el. But you can register your own command for some languages")
 
 (defun quickrun/copy-region-to-tempfile (start end dst)
   ;; Suppress write file message
-  (let ((str (buffer-substring-no-properties start end)))
+  (let ((str (buffer-substring-no-properties start end))
+        (codec buffer-file-coding-system))
     (with-temp-file dst
+      (set-buffer-file-coding-system codec)
       (insert str))
     (quickrun/add-remove-files dst)))
 


### PR DESCRIPTION
Current version of emacs-quickrun works incorrectly for Haskell source file with unicode symbols such as `★` in my environment (encoding of source file is utf-8, but the default encoding for writing is chinese-gbk).

Tests shipped with emacs-quickrun have been run and get expected results.
