### PR TITLE
Update for newer Xcode

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -376,7 +376,7 @@
               (:description . "Run Tcl script")))
 
     ("swift" . ((:command . "xcrun")
-                (:exec    . ("%c swift -i %s"))
+                (:exec    . ("%c swift %o %s %a"))
                 (:description . "Compile swift and execute")))
 
     ("ats" . ((:command . "patscc")


### PR DESCRIPTION
`-i` option is not necessary for newer Xcode.
