### PR TITLE
Add :tempfile attribute for Nim #71

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -399,6 +399,7 @@
     ("nim" . ((:command . "nim")
               (:exec . "%c compile --run --verbosity:0 %s")
               (:remove . ("nimcache" "%n"))
+              (:tempfile . nil)
               (:description . "Run nim script")))
 
     ("fish" . ((:command . "fish")


### PR DESCRIPTION
To be same behavior as command line, add :tempfile nil option.

For example, if there is file named array.nim and it is following
content, nim compiler emits error because of using same file name
and type name, but quickrun could success to compile if there is
no :tempfile attribute.

    var a: array[0..2, int] = [1, 2, 3]
    for ary in a:
      echo ary