### PR TITLE
Add configuration for NimScript

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -402,6 +402,13 @@
               (:tempfile . nil)
               (:description . "Run nim script")))
 
+    ("nimscript" . ((:command . "nim")
+                    (:exec . "%c e --verbosity:0 %s")
+                    (:tempfile . nil)
+                    ;; Note that .nimle file also allows ‘.ini’ format, so
+                    ;; we can’t check by file extension.
+                    (:description . "Run NimScript (.nims or .nimble) file")))
+
     ("fish" . ((:command . "fish")
                (:description . "Run fish script"))))
 
@@ -516,6 +523,7 @@ if you set your own language configuration.
     (ats-mode . "ats")
     (ess-mode . "r")
     (nim-mode . "nim")
+    (nimscript-mode . "nimscript")
     (fish-mode . "fish"))
   "Alist of major-mode and langkey")
 


### PR DESCRIPTION
Hi, I added a configuration for NimScript, which is subset of Nim programming language.
(http://nim-lang.org/0.11.3/nims.html)

In latest `nim-mode`, `nimscript-mode` was supported.

You can check nimscript following file content with M-x quickrun:

sample.nims
```nim
echo listDirs("./") # list directories
```

Note that NimScript format supports .nims and .nimble files, but 
the .nimble file also accepts `ini` format. So, I didn't add  `quickrun-file-alist`.