### PR TITLE
add racket to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ as default. But you can register your own command and apply other languages.
 * PHP(php)
 * Emacs Lisp(emacs)
 * Scheme(gosh)
+* Racket(racket)
 * Common Lisp(clisp or sbcl or ccl)
 * Clojure(jark or clj-env-dir)
 * Javascript(node or v8 or js or jrunscript or cscript)


### PR DESCRIPTION
I noticed that Racket is in the `quickrun/support-languages` variable, but not in the `README.md` file. I figured that it would be good to put it there so that Racket support is apparent to those who haven't yet installed `quickrun.el`.